### PR TITLE
Fixed compilation on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Mac stuff
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Preparation:
 *	In case the exodus export (EXODUS_LIBRARY) was enabled, define the path
 	to the root directory of a `netcdf` installation and 'exodusII' installation.
 
+* For macOS users, please check the version of macOS specified in the
+	`meshit.pro` file (line `QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15`). By default, the version of macOS specified is 10.15 (macOS Catalina)
+
+
 Building:
 *  `qmake meshit.pro`
 *  `make/nmake/mingw32-make`

--- a/meshit.pro
+++ b/meshit.pro
@@ -42,7 +42,7 @@ INCLUDEPATH += ./include
 
 # Mac
 macx {
-    # QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
 }
 
 # Linux
@@ -64,7 +64,7 @@ if($$EXODUS_LIBMESH) {
     INCLUDEPATH += . $$LIBMESH/include
     INCLUDEPATH += . $$LIBMESH/include/libmesh
     LIBS += -L$$LIBMESH/lib -lmesh_opt
-    QMAKE_LFLAGS += -Wl,-rpath,$$LIBMESH/lib
+    QMAKE_LFLAGS += -Wl,-rpath,$$LIBMESH
 }else:if($$EXODUS_LIBRARY) {
     INCLUDEPATH += . $$EXODUS_PATH/cbind/include
     LIBS += $$EXODUS_PATH/build/cbind/Release/exoIIv2c.lib


### PR DESCRIPTION
Fixed issues compiling MeshIt on macOS Catalina (10.15)

I also modified the README file. Users should check their macOS version and modify the `meshit.pro` file accordingly.

I also added a .gitignore file for automatic file generated by macOS. It would be nice to add there all the files automatically generated during compilation.